### PR TITLE
Can't return a value from a void function

### DIFF
--- a/blatSrc/blat.c
+++ b/blatSrc/blat.c
@@ -697,7 +697,7 @@ void bigBlat(struct dnaSeq *untransList, int queryCount, char *queryFiles[], str
                         if (frame != cnt)
                         {
                             printf("Merge files failed\n");
-                            return 1;
+                            return;
                         }
                     }
                     out[i] = freopen(NULL, "w+", out[i]);


### PR DESCRIPTION
clang happens to find this if you use it for compilation:

```
21:20:31 BIOCONDA INFO (ERR) blatSrc/blat.c:700:29: error: void function 'bigBlat' should not return a value [-Wreturn-type] 
21:20:31 BIOCONDA INFO (ERR)                             return 1; 
21:20:31 BIOCONDA INFO (ERR)                             ^      ~
```