### PR TITLE
issue #20 fix multible definition

### DIFF
--- a/inc/htmshell.h
+++ b/inc/htmshell.h
@@ -160,7 +160,7 @@ void htmlBadVar(char *varName);
 void htmlImage(char *fileName, int width, int height);
 /* Display centered image file. */
 
-jmp_buf htmlRecover;  /* Error recovery jump. Exposed for cart's use. */
+extern jmp_buf htmlRecover;  /* Error recovery jump. Exposed for cart's use. */
 
 void htmlVaWarn(char *format, va_list args);
 /* Write an error message.  (Generally you just call warn() or errAbort().


### PR DESCRIPTION
Add extern to htmlRecover to fix multiple definition errors with GCC >= 10